### PR TITLE
fix nil reference

### DIFF
--- a/lib/kovid/tablelize.rb
+++ b/lib/kovid/tablelize.rb
@@ -230,7 +230,7 @@ module Kovid
         end
 
         # From dates where number of !cases.zero?
-        positive_cases_figures = country['timeline']['cases'].values.reject!(&:zero?)
+        positive_cases_figures = country['timeline']['cases'].values.reject(&:zero?)
         dates = country['timeline']['cases'].reject { |_k, v| v.zero? }.keys
         data = []
 


### PR DESCRIPTION
If `country['timeline']['cases'].values.reject!(&:zero?) doesn't reject anything, the result will be nil.